### PR TITLE
Added taxonomy page for tags

### DIFF
--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,0 +1,16 @@
+{{ partial "header.html" . }}
+
+<h1 id="title">All themes tagged with "{{ .Title | lower }}"</h1>
+
+<div class="row">
+    {{ range .Data.Pages }}
+        {{ .Render "thumbnail" }}
+    {{ end }}
+</div>
+
+<div class="row">
+    <div class="contribute">
+        <i class="icon-fork"></i><p>  If you want to be added to this page please send a <a href="https://github.com/spf13/hugoThemes/pulls">pull request</a>.</p>
+    </div>
+</div>
+{{ partial "footer.html" . }}


### PR DESCRIPTION
Now all themes will be listed on their their corresponding tag taxonomy page.
