### PR TITLE
Adds Gohugo twitter handle to config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -7,8 +7,8 @@ theme = "gohugo-theme"
 plainIdAnchors=true
 config = "config-tpl-base.toml"
 
-[params]
-twitterhandle = "GoHugoIO"
+[social]
+twitter = "GoHugoIO"
 
 
   # GLOBAL = IF ANYTHING CHANGES BELOW UPDATE MAIN, DOCS, THEMES


### PR DESCRIPTION
This format supports Hugo's internal templates, as mentioned https://github.com/spf13/hugoThemesSite/issues/40

Relevant line in Hugo internal template: https://github.com/spf13/hugo/blob/b6ea492b7a6325d04d44eeb00a990a3a0e29e0c0/tpl/tplimpl/template_embedded.go#L242