### PR TITLE
Add netlify deploy config to specify environment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  command = "hugo"
+  publish = "public"
+
+[context.production.environment]
+  HUGO_VERSION = "0.21"
+  HUGO_ENV = "production"
+
+# https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/
+# https://www.netlify.com/docs/continuous-deployment/#deploy-contexts


### PR DESCRIPTION
In the theme for Hugo sites, some settings, like meta-index, are keyed off the environment variable. This file make it easy to set the environment for Netlify and can be used in the future to set multiple environments, if needed. 

Also, the Hugo version can be set in this file, according to this [blog post](https://www.netlify.com/blog/2017/04/11/netlify-plus-hugo-0.20-and-beyond/).