### PR TITLE
Themes by tag - display by last mod

### DIFF
--- a/layouts/taxonomy/tag.html
+++ b/layouts/taxonomy/tag.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
-  {{ $section_to_display := .Data.Pages }}
+  {{ $section_to_display := .Data.Pages.ByLastmod.Reverse }}
   {{ partial "pagelayout.html" (dict "context" . "section_to_display" $section_to_display)  }}
 {{ end }}


### PR DESCRIPTION
The main themes page sorts themes by last modified (from most recent to oldest). It would be useful if it did the same when you filter by tags.
Note: I couldn't work out how to run the themes site locally (no errors, just showed blank - guessing it needs another repo or sth to pull the themes in), so this change is a bit of a guess.