### PR TITLE
Prepare for Hugo 0.60.0

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,10 @@ googleAnalytics = "UA-7131036-4"
 
 disableKinds = ["taxonomyTerm"]
 
+#due to math typesetting issues in goldmark see: https://github.com/gohugoio/hugo/issues/6544
+[markup]
+  defaultMarkdownHandler = "blackfriday"
+
 [module]
   [module.hugoVersion]
     min = "0.56.0"


### PR DESCRIPTION
@bep 

In this PR I am setting the ThemesSite to continue using blackfriday up until the math typesetting issues in goldmark are resolved.

ref: https://github.com/gohugoio/hugo/issues/6544